### PR TITLE
WIP: refactor(Query): refactor query life-cycle 

### DIFF
--- a/lib/Query.js
+++ b/lib/Query.js
@@ -753,46 +753,138 @@ class Query {
   }
 
   /**
-   * Called before a query is sent to the database. This allows manipulating the
-   * sql if needed, even changing it entirely.
+   * Runs a query. This method calls {@link Query#acquireClient} to acquire a
+   * client, {@link Query#formatSql} to format the SQL to be run,
+   * {@link Query#runQuery} to run the SQL, {@link Query#parseResult} to parse
+   * the database result and finally {@link Query#releaseClient} to release the
+   * client.
    *
-   * NOTE: if this method returns anything, that will be used as the sql to send
-   * to the database instead. Therefore, this should be valid sql as expected by
-   * {@link Query#query}.
+   * @param {SqlBricks|object|string} sql The SQL to run.
    *
-   * @param {Client} client the database client that will be used to run the
-   * query.
-   * @param {SqlBricks|object|string} sql the sql that will be sent to the
-   * database.
+   * @returns {Promise} a promise that is resolved with the result from running
+   * the query.
    */
-  async beforeQuery() {}
+  async query(sql) {
+    const client = await this.acquireClient();
+
+    try {
+      const formattedSql = this.formatSql(sql);
+      const result = await this.runQuery(client, formattedSql);
+      const rows = this.parseResult(result);
+
+      return rows;
+    } finally {
+      await this.releaseClient(client);
+    }
+  }
 
   /**
-   * Called after a query is sent to the database. This allows manipulating the
-   * result if needed, even changing it entirely.
+   * Called by {@link Query#query} to get a client, ideally from a connection
+   * pool, to use for running a query.
    *
-   * NOTE: if this method returns anything, that will be used as the result of
-   * the query instead. Therefore, this should be a valid result object as
-   * expected by {@link Query#query}.
+   * ::: tip INFO
+   * This method is normally implemented by a plugin that provides database
+   * connectivitiy.
+   * :::
    *
-   * @param {Client} client the database client that was used to run the query.
-   * @param {SqlBricks|object|string} sql the sql that was sent to the
-   * database to generate the result.
-   * @param {object} result the result from the database.
+   * @returns {Promise<Client>} a promise that is resolved with the database
+   * client. If the method has not been implemented, the promise is rejected
+   * with a {@link QueryError}.
    */
-  async afterQuery() {}
+  async acquireClient() {
+    throw new this.constructor.QueryError(
+      '`Query.prototype.acquireClient` is not implemented'
+    );
+  }
 
   /**
-   * Runs a query. This method is not implemented in @knorm/knorm, it's meant to
-   * be implemented by a plugin that provides database access.
+   * Called by {@link Query#query} before a query is sent to the database. This
+   * allows manipulating the SQL if needed, even changing it entirely.
    *
-   * @param {SqlBricks|object|string} sql
+   * ::: tip INFO
+   * This method is normally implemented by plugins to format the SQL passed to
+   * {@link Query#query} before it's passed on to {@link Query#runQuery}.
+   * :::
    *
-   * @throws {QueryError} if the method is not implemented.
+   * @param {SqlBricks|object|string} sql The SQL to be formatted.
+   *
+   * @returns {SqlBricks|object|string} The formatted SQL.
+   *
+   * @throws {QueryError} If the method is not implemented.
    */
-  async query() {
+  formatSql() {
+    throw new this.constructor.QueryError(
+      '`Query.prototype.formatSql` is not implemented'
+    );
+  }
+
+  /**
+   * Called by {@link Query#query} to run a query against the database.
+   *
+   * ::: tip INFO
+   * This method is normally implemented by a plugin that provides database
+   * connectivitiy.
+   * :::
+   *
+   * @param {Client} client The database client that will be used to run the
+   * query. This is the same client that is acquired via
+   * {@link Query#acquireClient}.
+   * @param {SqlBricks|object|string} sql The SQL to be run, after it's
+   * formatted via {@link Query#formatSql}.
+   *
+   * @returns {Promise<object>} a promise that is resolved with the result from
+   * the database. If the method has not been implemented, the promise is
+   * rejected with a {@link QueryError}.
+   */
+  async runQuery() {
     throw new this.constructor.QueryError(
       '`Query.prototype.query` is not implemented'
+    );
+  }
+
+  /**
+   * Called by {@link Query#query} after a query is has been run via
+   * {@link Query#runQuery}. This allows manipulating the result if needed, even
+   * changing it entirely.
+   *
+   * ::: tip INFO
+   * This method is normally implemented by plugins to parse the query result
+   * from {@link Query#runQuery}.
+   * :::
+   *
+   * @param {object} result The query result to be parsed.
+   *
+   * @returns {Array<object>} An array of rows extracted from the query result.
+   *
+   * @throws {QueryError} If the method is not implemented.
+   */
+  parseResult() {
+    throw new this.constructor.QueryError(
+      '`Query.prototype.parseResult` is not implemented'
+    );
+  }
+
+  /**
+   * Called by {@link Query#query} to release a client, ideally back into the
+   * connection pool, after running a query.
+   *
+   * ::: tip INFO
+   * This method is normally implemented by a plugin that provides database
+   * connectivitiy.
+   * :::
+   *
+   * ::: tip INFO
+   * After a client is successfully acquired via {@link Query#acquireClient},
+   * this method is always called to ensure that the client is restored back to
+   * the pool, even if {@link Query#formatSql}, {@link Query#runQuery} or
+   * {@link Query#parseResult} fail.
+   * :::
+   *
+   * @param {Client} client The client to be released.
+   */
+  async releaseClient() {
+    throw new this.constructor.QueryError(
+      '`Query.prototype.releaseClient` is not implemented'
     );
   }
 

--- a/lib/Query.js
+++ b/lib/Query.js
@@ -761,8 +761,8 @@ class Query {
    *
    * @param {SqlBricks|object|string} sql The SQL to run.
    *
-   * @returns {Promise<Array>} A promise that is resolved with the parsed result
-   * from running a query.
+   * @returns {Promise} A promise that is resolved with the parsed result from
+   * running a query.
    */
   async query(sql) {
     const client = await this.acquireClient();
@@ -831,7 +831,7 @@ class Query {
    * @param {Client} client The database client that will be used to run the
    * query. This is the same client that is acquired via
    * {@link Query#acquireClient}.
-   * @param {SqlBricks|object|string} sql The SQL to be run, after it's
+   * @param {SqlBricks|object|string} formattedSql The SQL to be run, after it's
    * formatted via {@link Query#formatSql}.
    *
    * @returns {object|Promise} The result from the database or a promise that is
@@ -857,8 +857,8 @@ class Query {
    *
    * @param {object} result The query result to be parsed.
    *
-   * @returns {Array<object>|Promise} An array of rows extracted from the query
-   * result or a promise resolving with the extracted rows.
+   * @returns {Array|Promise} An array of rows extracted from the query result
+   * or a promise resolving with the extracted rows.
    *
    * @throws {QueryError} If the method is not implemented.
    */

--- a/lib/Query.js
+++ b/lib/Query.js
@@ -761,16 +761,16 @@ class Query {
    *
    * @param {SqlBricks|object|string} sql The SQL to run.
    *
-   * @returns {Promise} a promise that is resolved with the result from running
-   * the query.
+   * @returns {Promise<Array>} A promise that is resolved with the parsed result
+   * from running a query.
    */
   async query(sql) {
     const client = await this.acquireClient();
 
     try {
-      const formattedSql = this.formatSql(sql);
+      const formattedSql = await this.formatSql(sql);
       const result = await this.runQuery(client, formattedSql);
-      const rows = this.parseResult(result);
+      const rows = await this.parseResult(result);
 
       return rows;
     } finally {
@@ -787,11 +787,12 @@ class Query {
    * connectivitiy.
    * :::
    *
-   * @returns {Promise<Client>} a promise that is resolved with the database
-   * client. If the method has not been implemented, the promise is rejected
-   * with a {@link QueryError}.
+   * @returns {Client|Promise} A database client or a promise that is resolved
+   * with the database client.
+   *
+   * @throws {QueryError} If the method is not implemented.
    */
-  async acquireClient() {
+  acquireClient() {
     throw new this.constructor.QueryError(
       '`Query.prototype.acquireClient` is not implemented'
     );
@@ -808,7 +809,8 @@ class Query {
    *
    * @param {SqlBricks|object|string} sql The SQL to be formatted.
    *
-   * @returns {SqlBricks|object|string} The formatted SQL.
+   * @returns {SqlBricks|object|string|Promise} The formatted SQL or a promise
+   * that is resolved with the formatted SQL.
    *
    * @throws {QueryError} If the method is not implemented.
    */
@@ -832,13 +834,14 @@ class Query {
    * @param {SqlBricks|object|string} sql The SQL to be run, after it's
    * formatted via {@link Query#formatSql}.
    *
-   * @returns {Promise<object>} a promise that is resolved with the result from
-   * the database. If the method has not been implemented, the promise is
-   * rejected with a {@link QueryError}.
+   * @returns {object|Promise} The result from the database or a promise that is
+   * resolved with the database result.
+   *
+   * @throws {QueryError} If the method is not implemented.
    */
-  async runQuery() {
+  runQuery() {
     throw new this.constructor.QueryError(
-      '`Query.prototype.query` is not implemented'
+      '`Query.prototype.runQuery` is not implemented'
     );
   }
 
@@ -854,7 +857,8 @@ class Query {
    *
    * @param {object} result The query result to be parsed.
    *
-   * @returns {Array<object>} An array of rows extracted from the query result.
+   * @returns {Array<object>|Promise} An array of rows extracted from the query
+   * result or a promise resolving with the extracted rows.
    *
    * @throws {QueryError} If the method is not implemented.
    */
@@ -881,8 +885,13 @@ class Query {
    * :::
    *
    * @param {Client} client The client to be released.
+   *
+   * @returns {undefined|Promise} Returns nothing or a promise that is resolved
+   * when the client is released.
+   *
+   * @throws {QueryError} If the method is not implemented.
    */
-  async releaseClient() {
+  releaseClient() {
     throw new this.constructor.QueryError(
       '`Query.prototype.releaseClient` is not implemented'
     );

--- a/test/lib/postgresPlugin.js
+++ b/test/lib/postgresPlugin.js
@@ -24,8 +24,23 @@ const postgresPlugin = knorm => {
       return super.prepareSql(sql, options);
     }
 
-    async query(sql) {
-      const result = await pool.query(sql.toParams());
+    async acquireClient() {
+      return pool.connect();
+    }
+
+    async releaseClient(client) {
+      client.release();
+    }
+
+    formatSql(sql) {
+      return sql.toParams();
+    }
+
+    async runQuery(client, sql) {
+      return client.query(sql);
+    }
+
+    parseResult(result) {
       return result.rows;
     }
   }


### PR DESCRIPTION
Makes the Query-related changes referred to in  #102 

- [x] rename `beforeQuery` to `formatSql` and remove the `client` param?
- [x] rename `afterQuery` to `parseResult` and remove the `client` and `sql` params?
- [x] rename `runQuery` to `_query`? _won't do_
- [x] add query-hook options https://github.com/knorm/knorm/issues/175 _later_
- [x] document breaking changes
- [x] merge into v2