### PR TITLE
refactor(Field): rename `schema` validator to `shape`

### DIFF
--- a/docs/guides/fields.md
+++ b/docs/guides/fields.md
@@ -64,7 +64,7 @@ For object configs, these options are supported:
 | `equals`     | mixed                       | none           | Validates that the field's value is equal to this value. Uses strict equality and case-sensitive matching for strings.                                                                   |
 | `regex`      | RegExp / object             | none           | Validates that the field's value either matches or does not match a regular expression, or both. See [regex validation](guides/validation.md#regex-validation)                           |
 | `validate`   | function                    | none           | Validates the field's value against a custom validation function. See [custom validation](guides/validation.md#custom-validation)                                                        |
-| `schema`     | string / object             | none           | Validates the structure of `json` (and `jsonb`) feilds. See [JSON validation](guides/validation.md#json-validation)                                                                      |
+| `shape`     | string / object             | none           | Validates the structure of `json` (and `jsonb`) feilds. See [JSON validation](guides/validation.md#json-validation)                                                                      |
 
 ## Field types
 

--- a/docs/guides/validation.md
+++ b/docs/guides/validation.md
@@ -187,7 +187,7 @@ be called if the value is `null`.
 
 For [json](http://knexjs.org/#Schema-json) (and
 [jsonb](http://knexjs.org/#Schema-jsonb)) fields, you can have the JSON values
-validated by adding a `schema` object to the field definition object.
+validated by adding a `shape` object to the field definition object.
 
 ```js {6,7,8,9,10}
 class Upload extends Model {}
@@ -195,7 +195,7 @@ class Upload extends Model {}
 Upload.fields = {
   image: {
     type: 'jsonb',
-    schema: {
+    shape: {
       filename: { type: 'string' },
       mimetype: { type: 'string', oneOf: ['image/jpeg', 'image/png'] },
       data: { type: 'binary', required: true }
@@ -204,7 +204,7 @@ Upload.fields = {
 };
 ```
 
-With this schema, these are valid:
+With this config, these are valid:
 
 ```js
 new Upload({
@@ -230,13 +230,13 @@ new Upload({
 ```
 
 ::: tip INFO
-JSON `schema` validators support all the
-[validators](/guides/fields.md#field-config), including nested `schema`
+JSON `shape` validators support all the
+[validators](/guides/fields.md#field-config), including nested `shape`
 validators [for nested objects](#nested-objects).
 :::
 
 ::: tip
-You may also define the schema with the `fieldName: fieldType` shorthand:
+You may also define the shape with the `fieldName: fieldType` shorthand:
 :::
 
 ```js {7,8}
@@ -245,7 +245,7 @@ class User extends Model {}
 User.fields = {
   data: {
     type: 'jsonb',
-    schema: {
+    shape: {
       firstName: 'string',
       lastName: 'string'
     }
@@ -255,8 +255,8 @@ User.fields = {
 
 ### JSON arrays
 
-For JSON arrays, use the `array` field type. You can also define the schema of a
-single array item by passing a `schema` validation object with the regular
+For JSON arrays, use the `array` field type. You can also define the shape of a
+single array item by passing a `shape` validation object with the regular
 [validators](/guides/fields.md#field-config).
 
 ```js {12,14,15,16,17}
@@ -265,7 +265,7 @@ class SomeData extends Model {}
 SomeData.fields = {
   data: {
     type: 'json',
-    schema: {
+    shape: {
       currentVersion: {
         type: 'string',
         required: true
@@ -273,7 +273,7 @@ SomeData.fields = {
       oldVersions: {
         type: 'array',
         maxLength: 2,
-        schema: {
+        shape: {
           type: 'string',
           required: true
         }
@@ -293,7 +293,7 @@ const someData = new SomeData({
 ### Nested objects
 
 For nested objects, use the `object` field type. You can also define the nested
-object's schema with a nested `schema` validator.
+object's shape with a nested `shape` validator.
 
 ```js {8,9,10,11,12}
 class SomeData extends Model {}
@@ -301,10 +301,10 @@ class SomeData extends Model {}
 SomeData.fields = {
   data: {
     type: 'json',
-    schema: {
+    shape: {
       nested: {
         type: 'object',
-        schema: {
+        shape: {
           someField: { type: 'string' },
           someOtherField: { type: 'number' }
         }
@@ -331,14 +331,14 @@ Nested object fields **should** contain a `type`, just like regular
 ### Root-level JSON fields
 
 For JSON fields whose values are not nested in an object, define their
-validators with a `schema` validator:
+validators with a `shape` validator:
 
 ```js {5,6,7,8,9,18,19,20,21}
 class SomeData extends Model {}
 SomeData.fields = {
   value: {
     type: 'json',
-    schema: {
+    shape: {
       type: 'string',
       required: true,
       maxLength: 255
@@ -351,7 +351,7 @@ class RootLevelArray extends Model {}
 RootLevelArray.fields = {
   value: {
     type: 'array',
-    schema: {
+    shape: {
       required: true,
       type: 'string'
     }
@@ -360,7 +360,7 @@ RootLevelArray.fields = {
 const rootLevelArray = new RootLevelArray({ value: ['some value'] });
 ```
 
-Note that you may also define the schema with the `fieldName: fieldType`
+Note that you may also define the shape with the `fieldName: fieldType`
 shorthand:
 
 ```js {6}
@@ -369,7 +369,7 @@ class User extends Model {}
 User.fields = {
   data: {
     type: 'jsonb',
-    schema: 'string'
+    shape: 'string'
   }
 };
 ```

--- a/lib/Field.js
+++ b/lib/Field.js
@@ -110,7 +110,7 @@ class Field {
       oneOf,
       equals,
       regex,
-      schema
+      shape
     } = config;
 
     const validators = { type };
@@ -136,23 +136,23 @@ class Field {
     if (regex) {
       validators.regex = regex;
     }
-    if (schema) {
-      validators.schema = this._createSchemaValidators(schema);
+    if (shape) {
+      validators.shape = this._createShapeValidators(shape);
     }
 
     return validators;
   }
 
   // TODO: write regression tests for `new Field` vs `new this.constructor`
-  _createSchemaValidators(schema) {
-    if (typeof schema === 'string') {
-      schema = { type: schema };
+  _createShapeValidators(shape) {
+    if (typeof shape === 'string') {
+      shape = { type: shape };
     }
 
-    if (schema.type && typeof schema.type === 'string') {
-      // is item schema
+    if (shape.type && typeof shape.type === 'string') {
+      // is item shape
       return new this.constructor(
-        Object.assign({}, schema, {
+        Object.assign({}, shape, {
           name: this.name,
           path: this.path,
           model: this.model
@@ -160,10 +160,10 @@ class Field {
       );
     }
 
-    return Object.keys(schema).reduce((validators, key) => {
+    return Object.keys(shape).reduce((validators, key) => {
       let name;
       let path;
-      let config = schema[key];
+      let config = shape[key];
 
       if (typeof config === 'string') {
         config = { type: config };
@@ -490,12 +490,12 @@ class Field {
     }
   }
 
-  async validateWithSchema(value, schema, modelInstance) {
-    const isRootSchema = schema instanceof Field;
+  async validateWithShape(value, shape, modelInstance) {
+    const isRootShape = shape instanceof Field;
 
     if (
       typeof value === 'string' &&
-      !(isRootSchema && schema.type === 'string')
+      !(isRootShape && shape.type === 'string')
     ) {
       try {
         value = JSON.parse(value);
@@ -504,24 +504,24 @@ class Field {
       }
     }
 
-    if (isRootSchema) {
+    if (isRootShape) {
       if (this.type === 'array') {
         if (!value || !value.length) {
-          if (schema.validators.required) {
-            schema.valueIndex = undefined;
-            schema.throwValidationError(value, { required: true });
+          if (shape.validators.required) {
+            shape.valueIndex = undefined;
+            shape.throwValidationError(value, { required: true });
           } else {
             return true;
           }
         }
         return Promise.all(
           value.map(async (item, index) => {
-            schema.valueIndex = index;
-            return schema.validate(item, modelInstance);
+            shape.valueIndex = index;
+            return shape.validate(item, modelInstance);
           })
         );
       } else {
-        return schema.validate(value, modelInstance);
+        return shape.validate(value, modelInstance);
       }
     }
 
@@ -530,7 +530,7 @@ class Field {
     }
 
     return Promise.all(
-      Object.values(schema).map(async field =>
+      Object.values(shape).map(async field =>
         field.validate(value[field.name], modelInstance)
       )
     );
@@ -546,7 +546,7 @@ class Field {
       equals,
       regex,
       validate,
-      schema
+      shape
     } = validators;
 
     if (required) {
@@ -578,8 +578,8 @@ class Field {
         this.validateWithRegex(value, regex);
       }
 
-      if (schema) {
-        await this.validateWithSchema(value, schema, modelInstance);
+      if (shape) {
+        await this.validateWithShape(value, shape, modelInstance);
       }
     }
 

--- a/test/Field.spec.js
+++ b/test/Field.spec.js
@@ -163,54 +163,54 @@ describe('Field', function() {
       });
     });
 
-    describe('for `json` and `jsonb` fields with a `schema` config', function() {
+    describe('for `json` and `jsonb` fields with a `shape` config', function() {
       let Foo;
 
       before(function() {
         Foo = class extends Model {};
       });
 
-      describe('with a root-level schema', function() {
-        it('throws the correct error if the schema config has no `type`', function() {
+      describe('with a root-level `shape`', function() {
+        it('throws the correct error if the shape config has no `type`', function() {
           expect(
             () =>
               new Field({
                 name: 'json',
                 model: Foo,
                 type: 'json',
-                schema: { required: true }
+                shape: { required: true }
               }),
             'to throw',
             new Error('Field `Foo.json` has no type configured')
           );
         });
 
-        it('throws the correct error if a schema config has an invalid `type`', function() {
+        it('throws the correct error if a shape config has an invalid `type`', function() {
           expect(
             () =>
               new Field({
                 name: 'json',
                 model: Foo,
                 type: 'json',
-                schema: { type: 'foo', required: true }
+                shape: { type: 'foo', required: true }
               }),
             'to throw',
             new Error('Field `Foo.json` has an invalid type `foo`')
           );
         });
 
-        it("allows adding schema fields with the `schema: 'type'` shorthand", function() {
+        it("allows adding shape validators with the `shape: 'type'` shorthand", function() {
           expect(
             new Field({
               name: 'json',
               model: Foo,
               type: 'array',
-              schema: 'string'
+              shape: 'string'
             }),
             'to satisfy',
             {
               validators: {
-                schema: expect.it(
+                shape: expect.it(
                   'to be field',
                   new Field({
                     name: 'json',
@@ -225,7 +225,7 @@ describe('Field', function() {
         });
       });
 
-      describe('with a schema with nested fields', function() {
+      describe('with a shape with nested fields', function() {
         it('throws the correct error if a nested field has no `type`', function() {
           expect(
             () =>
@@ -233,7 +233,7 @@ describe('Field', function() {
                 name: 'json',
                 model: Foo,
                 type: 'json',
-                schema: { foo: { required: true } }
+                shape: { foo: { required: true } }
               }),
             'to throw',
             new Error('Field `Foo.json.foo` has no type configured')
@@ -247,25 +247,25 @@ describe('Field', function() {
                 name: 'json',
                 model: Foo,
                 type: 'json',
-                schema: { foo: { type: 'foo', required: true } }
+                shape: { foo: { type: 'foo', required: true } }
               }),
             'to throw',
             new Error('Field `Foo.json.foo` has an invalid type `foo`')
           );
         });
 
-        it("allows adding schema fields with the `schema: 'type'` shorthand", function() {
+        it("allows adding shape validators with the `shape: 'type'` shorthand", function() {
           expect(
             new Field({
               name: 'json',
               model: Foo,
               type: 'json',
-              schema: { foo: 'string' }
+              shape: { foo: 'string' }
             }),
             'to satisfy',
             {
               validators: {
-                schema: {
+                shape: {
                   foo: expect.it(
                     'to be field',
                     new Field({
@@ -1632,7 +1632,7 @@ describe('Field', function() {
     });
 
     describe('for `json` and `jsonb` fields', function() {
-      describe('without a `schema` configured', function() {
+      describe('without a `shape` configured', function() {
         let json;
         let jsonb;
 
@@ -1692,7 +1692,7 @@ describe('Field', function() {
             name: 'json',
             model: User,
             type: 'json',
-            schema: { foo: { type: 'string' } }
+            shape: { foo: { type: 'string' } }
           });
         });
 
@@ -1712,20 +1712,20 @@ describe('Field', function() {
           await expect(field.validate('{"foo":"foo"}'), 'to be fulfilled');
         });
 
-        describe('with a root-level `string` schema', function() {
+        describe('with a root-level `string` shape', function() {
           it('does not JSON.parse the value', async function() {
             const field = new Field({
               name: 'json',
               model: User,
               type: 'json',
-              schema: 'string'
+              shape: 'string'
             });
             await expect(field.validate('foo'), 'to be fulfilled');
           });
         });
       });
 
-      describe('with a root-level `schema` object', function() {
+      describe('with a root-level `shape` object', function() {
         let field;
 
         before(function() {
@@ -1733,7 +1733,7 @@ describe('Field', function() {
             name: 'json',
             model: User,
             type: 'json',
-            schema: { type: 'string', required: true }
+            shape: { type: 'string', required: true }
           });
         });
 
@@ -1788,7 +1788,7 @@ describe('Field', function() {
               name: 'firstName',
               model: User,
               type: 'json',
-              schema: { type: 'string', validate }
+              shape: { type: 'string', validate }
             });
           });
 
@@ -1817,7 +1817,7 @@ describe('Field', function() {
                 name: 'firstName',
                 model: User,
                 type: 'json',
-                schema: { type: 'string', validate: () => ({ maxLength: 2 }) }
+                shape: { type: 'string', validate: () => ({ maxLength: 2 }) }
               });
               await expect(field.validate('ba'), 'to be fulfilled');
               await expect(field.validate('bar'), 'to be rejected with', {
@@ -1826,17 +1826,17 @@ describe('Field', function() {
               });
             });
 
-            it('supports new `schema` validators', async function() {
+            it('supports new `shape` validators', async function() {
               const field = new Field({
                 name: 'firstName',
                 model: User,
                 type: 'json',
-                schema: {
+                shape: {
                   type: 'object',
                   validate: () => ({
                     type: 'object',
-                    schema: {
-                      foo: { type: 'array', schema: { type: 'number' } }
+                    shape: {
+                      foo: { type: 'array', shape: { type: 'number' } }
                     }
                   })
                 }
@@ -1849,14 +1849,14 @@ describe('Field', function() {
               );
             });
 
-            it('supports new `schema` validators without a `type`', async function() {
+            it('supports new `shape` validators without a `type`', async function() {
               const field = new Field({
                 name: 'firstName',
                 model: User,
                 type: 'json',
-                schema: {
+                shape: {
                   type: 'object',
-                  validate: () => ({ schema: { foo: 'number' } })
+                  validate: () => ({ shape: { foo: 'number' } })
                 }
               });
               await expect(field.validate({ foo: 1 }), 'to be fulfilled');
@@ -1869,7 +1869,7 @@ describe('Field', function() {
           });
         });
 
-        describe('with a root-level `array` field with an item `schema`', function() {
+        describe('with a root-level `array` field with an item `shape`', function() {
           let field;
 
           before(function() {
@@ -1877,10 +1877,10 @@ describe('Field', function() {
               name: 'json',
               model: User,
               type: 'json',
-              schema: {
+              shape: {
                 type: 'array',
                 maxLength: 2,
-                schema: { type: 'string' }
+                shape: { type: 'string' }
               }
             });
           });
@@ -1919,16 +1919,16 @@ describe('Field', function() {
             await expect(field.validate([]), 'to be fulfilled');
           });
 
-          describe('with the item schema `required`', function() {
+          describe('with the item shape specifying `required`', function() {
             before(function() {
               field = new Field({
                 name: 'json',
                 model: User,
                 type: 'json',
-                schema: {
+                shape: {
                   type: 'array',
                   maxLength: 2,
-                  schema: { type: 'string', required: true }
+                  shape: { type: 'string', required: true }
                 }
               });
             });
@@ -1956,7 +1956,7 @@ describe('Field', function() {
           });
         });
 
-        describe('with a root-level `array` field with no item `schema`', function() {
+        describe('with a root-level `array` field with no item `shape`', function() {
           let field;
 
           before(function() {
@@ -1964,7 +1964,7 @@ describe('Field', function() {
               name: 'json',
               model: User,
               type: 'json',
-              schema: { type: 'array', minLength: 2 }
+              shape: { type: 'array', minLength: 2 }
             });
           });
 
@@ -1988,7 +1988,7 @@ describe('Field', function() {
           });
         });
 
-        describe('with a root-level `array` field with a nested `schema`', function() {
+        describe('with a root-level `array` field with a nested `shape`', function() {
           let field;
 
           before(function() {
@@ -1996,11 +1996,11 @@ describe('Field', function() {
               name: 'json',
               model: User,
               type: 'json',
-              schema: {
+              shape: {
                 type: 'array',
-                schema: {
+                shape: {
                   type: 'object',
-                  schema: { foo: { type: 'string' } }
+                  shape: { foo: { type: 'string' } }
                 }
               }
             });
@@ -2024,7 +2024,7 @@ describe('Field', function() {
             );
           });
 
-          it('ignores nested keys that are not defined in the schema', async function() {
+          it('ignores nested keys that are not defined in the shape', async function() {
             await expect(
               field.validate([{ foo: 'foo', bar: 1 }]),
               'to be fulfilled'
@@ -2040,7 +2040,7 @@ describe('Field', function() {
           });
         });
 
-        describe('with a root-level `object` field with a nested `schema`', function() {
+        describe('with a root-level `object` field with a nested `shape`', function() {
           let field;
 
           before(function() {
@@ -2048,11 +2048,11 @@ describe('Field', function() {
               name: 'json',
               model: User,
               type: 'json',
-              schema: {
+              shape: {
                 type: 'object',
-                schema: {
+                shape: {
                   type: 'object',
-                  schema: { foo: { type: 'string' } }
+                  shape: { foo: { type: 'string' } }
                 }
               }
             });
@@ -2080,7 +2080,7 @@ describe('Field', function() {
             });
           });
 
-          it('ignores nested keys that are not defined in the schema', async function() {
+          it('ignores nested keys that are not defined in the shape', async function() {
             await expect(
               field.validate({ foo: 'foo', bar: 1 }),
               'to be fulfilled'
@@ -2108,7 +2108,7 @@ describe('Field', function() {
           });
         });
 
-        describe('with a root-level `object` field  with no nested `schema`', function() {
+        describe('with a root-level `object` field  with no nested `shape`', function() {
           let field;
 
           before(function() {
@@ -2116,9 +2116,7 @@ describe('Field', function() {
               name: 'json',
               model: User,
               type: 'json',
-              schema: {
-                type: 'object'
-              }
+              shape: { type: 'object' }
             });
           });
 
@@ -2147,7 +2145,7 @@ describe('Field', function() {
         });
       });
 
-      describe('with a `schema` object with nested fields', function() {
+      describe('with a `shape` object with nested fields', function() {
         let field;
 
         before(function() {
@@ -2155,7 +2153,7 @@ describe('Field', function() {
             name: 'json',
             model: User,
             type: 'json',
-            schema: { foo: { type: 'string', required: true } }
+            shape: { foo: { type: 'string', required: true } }
           });
         });
 
@@ -2179,7 +2177,7 @@ describe('Field', function() {
           await expect(field.validate({ foo: 'bar' }), 'to be fulfilled');
         });
 
-        it('ignores object keys that are not specified in the schema', async function() {
+        it('ignores object keys that are not specified in the shape', async function() {
           await expect(
             field.validate({ foo: 'foo', bar: [] }),
             'to be fulfilled'
@@ -2204,7 +2202,7 @@ describe('Field', function() {
               name: 'firstName',
               model: User,
               type: 'json',
-              schema: { foo: { type: 'string', validate } }
+              shape: { foo: { type: 'string', validate } }
             });
           });
 
@@ -2233,7 +2231,7 @@ describe('Field', function() {
                 name: 'firstName',
                 model: User,
                 type: 'json',
-                schema: {
+                shape: {
                   foo: { type: 'string', validate: () => ({ maxLength: 2 }) }
                 }
               });
@@ -2244,18 +2242,18 @@ describe('Field', function() {
               );
             });
 
-            it('supports new `schema` validators', async function() {
+            it('supports new `shape` validators', async function() {
               const field = new Field({
                 name: 'firstName',
                 model: User,
                 type: 'json',
-                schema: {
+                shape: {
                   foo: {
                     type: 'object',
                     validate: () => ({
                       type: 'object',
-                      schema: {
-                        bar: { type: 'array', schema: { type: 'number' } }
+                      shape: {
+                        bar: { type: 'array', shape: { type: 'number' } }
                       }
                     })
                   }
@@ -2272,15 +2270,15 @@ describe('Field', function() {
               );
             });
 
-            it('supports new `schema` validators without a `type`', async function() {
+            it('supports new `shape` validators without a `type`', async function() {
               const field = new Field({
                 name: 'firstName',
                 model: User,
                 type: 'json',
-                schema: {
+                shape: {
                   foo: {
                     type: 'object',
-                    validate: () => ({ schema: { bar: 'number' } })
+                    validate: () => ({ shape: { bar: 'number' } })
                   }
                 }
               });
@@ -2297,7 +2295,7 @@ describe('Field', function() {
           });
         });
 
-        describe('with a nested `array` field with an item `schema`', function() {
+        describe('with a nested `array` field with an item `shape`', function() {
           let field;
 
           before(function() {
@@ -2305,11 +2303,11 @@ describe('Field', function() {
               name: 'json',
               model: User,
               type: 'json',
-              schema: {
+              shape: {
                 foo: {
                   type: 'array',
                   maxLength: 2,
-                  schema: { type: 'string', required: true }
+                  shape: { type: 'string', required: true }
                 }
               }
             });
@@ -2346,7 +2344,7 @@ describe('Field', function() {
             );
           });
 
-          it('ignores keys in the array items that are not specified in the schema', async function() {
+          it('ignores keys in the array items that are not specified in the shape', async function() {
             await expect(
               field.validate({ foo: ['foo'], bar: [] }),
               'to be fulfilled'
@@ -2362,7 +2360,7 @@ describe('Field', function() {
           });
         });
 
-        describe('with a nested `array` field with no item `schema`', function() {
+        describe('with a nested `array` field with no item `shape`', function() {
           let field;
 
           before(function() {
@@ -2370,7 +2368,7 @@ describe('Field', function() {
               name: 'json',
               model: User,
               type: 'json',
-              schema: { foo: { type: 'array', minLength: 2 } }
+              shape: { foo: { type: 'array', minLength: 2 } }
             });
           });
 
@@ -2406,10 +2404,10 @@ describe('Field', function() {
               name: 'json',
               model: User,
               type: 'json',
-              schema: {
+              shape: {
                 foo: {
                   type: 'object',
-                  schema: { bar: { type: 'integer', required: true } }
+                  shape: { bar: { type: 'integer', required: true } }
                 }
               }
             });
@@ -2438,15 +2436,15 @@ describe('Field', function() {
             );
           });
 
-          it('ignores object keys that are not specified in the nested schema', async function() {
+          it('ignores object keys that are not specified in the nested shape', async function() {
             await expect(
               field.validate({ foo: { bar: 1, quux: 'quux' } }),
               'to be fulfilled'
             );
           });
 
-          describe('with the nested schema `required`', function() {
-            it('rejects if the value is `undefined` and the schema specifies `required`', async function() {
+          describe('with the nested shape specifying `required`', function() {
+            it('rejects if the value is `undefined`', async function() {
               await expect(
                 field.validate({ foo: { bar: undefined } }),
                 'to be rejected with',
@@ -2526,12 +2524,12 @@ describe('Field', function() {
         await expect(field.validate(sql('b')), 'to be fulfilled');
       });
 
-      it('does not validate `schema` for json(b) fields', async function() {
+      it('does not validate `shape` for json(b) fields', async function() {
         const field = new Field({
           name: 'json',
           model: User,
           type: 'string',
-          schema: 'string'
+          shape: 'string'
         });
         await expect(field.validate(sql('b')), 'to be fulfilled');
       });


### PR DESCRIPTION
BREAKING CHANGE: JSON validators should now be configured with
a `shape` object (or string) instead of `schema`:

```js
Model.fields = {
  data: {
    type: 'jsonb',
    shape: { // instead of `shape`
      value1: 'string',
      value2: 'integer',
      value3: 'object'
    }
  }
};
```

Closes #85