### PR TITLE
feat(Query): pass query errors to Connection.prototype.close

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -41,6 +41,10 @@ class Connection {
    * Called by {@link Query#disconnect} and {@link Transaction#disconnect} to
    * close the connection created by {@link Connection#create}.
    *
+   * @param {QueryError} [error] If {@link Query#disconnect} was called with an
+   * error, that error is passed as this param. That error will have usually
+   * originated from {@link Query#query}.
+   *
    * @throws {ConnectionError} If the method is not implemented.
    */
   close() {

--- a/lib/Query.js
+++ b/lib/Query.js
@@ -847,21 +847,30 @@ class Query {
     await this.connect();
 
     let rows = [];
+    let queryError;
 
     try {
       await Promise.all(
         sqls.map(async sql => {
           const formattedSql = this.formatSql(sql);
-          const batchRows = await this.query(formattedSql).catch(e => {
+          let batchRows;
+
+          try {
+            batchRows = await this.query(formattedSql);
+          } catch (error) {
             const { text, values } = formattedSql;
-            e.sql = this.options.debug ? { text, values } : { text };
-            throw e;
-          });
+
+            error.sql = this.options.debug ? { text, values } : { text };
+            queryError = error;
+
+            throw error;
+          }
+
           rows = rows.concat(batchRows);
         })
       );
     } finally {
-      await this.disconnect();
+      await this.disconnect(queryError);
     }
 
     return rows;
@@ -965,11 +974,14 @@ class Query {
    * connections are closed as usual.
    * :::
    *
+   * @param {QueryError} [error] A {@link QueryError} from {@link Query#query},
+   * if one occurred. This error is then passed to {@link Connection#close}.
+   *
    * @returns {Promise} The `Promise` from {@link Connection#close}, that is
    * resolved when the connection is closed or rejected with a
    * {@link QueryError} on error.
    */
-  async disconnect() {
+  async disconnect(error) {
     const transaction = this.transaction;
 
     if (transaction && !transaction.ended) {
@@ -978,7 +990,7 @@ class Query {
     }
 
     try {
-      return await this.connection.close();
+      return await this.connection.close(error);
     } catch (e) {
       throw new this.constructor.QueryError(e);
     }

--- a/lib/Query.js
+++ b/lib/Query.js
@@ -810,13 +810,39 @@ class Query {
    * queried, {@link Query#query} to run the query against the database, and
    * finally, {@link Query#disconnect} to close the database connection.
    *
-   * ::: tip INFO
+   * ::: tip INFO: Usage
    * This method is used internally by all {@link Query} methods i.e.
    * {@link Query#fetch}, {@link Query#insert}, {@link Query#update} and
    * {@link Query#delete}.
    * :::
    *
-   * ::: tip INFO
+   * ::: tip INFO: Query errors
+   * If the promise from {@link Query#query} is rejected, the {@link QueryError}
+   * is passed to {@link Query#disconnect}.
+   * :::
+   *
+   * ::: tip INFO: Transactions
+   * When queries are executed in a transaction (that has not yet
+   * {@link Transaction#ended}), this method does not connect to the database
+   * via {@link Query#connect}. Instead, it connects via
+   * {@link Transaction#connect}. The first query to be executed in the
+   * transaction causes {@link Transaction#connect} and
+   * {@link Transaction#begin} to be run, after which subsequent queries re-use
+   * the transaction's connection.
+   *
+   * In addition, the database connection is not closed after executing the
+   * query. This is deferred to be handled by {@link Transaction#commit} or
+   * {@link Transaction#rollback}.
+   *
+   * If {@link Query#query} rejects with an error, the error is passed to
+   * {@link Transaction#rollback}.
+   *
+   * **NOTE:** once the transaction has {@link Transaction#ended}, connections
+   * are established and closed as usual, via {@link Query#connect} and
+   * {@link Query#disconnect}.
+   * :::
+   *
+   * ::: tip INFO: Multiple queries
    * When the `sql` parameter is an array, a single database connection will be
    * created but {@link Query#formatSql} and {@link Query#query} will be called
    * for each item in the array.
@@ -843,11 +869,25 @@ class Query {
    */
   async execute(sql) {
     const sqls = isArray(sql) ? sql : [sql];
+    const transaction = this.transaction;
 
-    await this.connect();
+    if (transaction && !transaction.ended) {
+      // when running in an active transaction, use the transaction's connection
+      if (!transaction.connection) {
+        // in the course of a transaction, Query#execute is bound to be called
+        // more than once, so ensure Transaction#connect and Transaction#begin
+        // are only run once once.
+        await transaction.connect();
+        await transaction.begin();
+      }
+
+      this.connection = transaction.connection;
+    } else {
+      await this.connect();
+    }
 
     let rows = [];
-    let queryError;
+    let error;
 
     try {
       await Promise.all(
@@ -857,20 +897,30 @@ class Query {
 
           try {
             batchRows = await this.query(formattedSql);
-          } catch (error) {
+          } catch (e) {
             const { text, values } = formattedSql;
 
-            error.sql = this.options.debug ? { text, values } : { text };
-            queryError = error;
+            e.sql = this.options.debug ? { text, values } : { text };
+            error = e;
 
-            throw error;
+            throw e;
           }
 
           rows = rows.concat(batchRows);
         })
       );
     } finally {
-      await this.disconnect(queryError);
+      if (transaction && !transaction.ended) {
+        if (error) {
+          // if there's an active transaction and an error occurs, roll back the
+          // transaction and disconnect (via Transaction#rollback)
+          await transaction.rollback(error);
+        }
+        // if there's no error, do nothing. defer closing the connection till
+        // the transaction is ended
+      } else {
+        await (error ? this.disconnect(error) : this.disconnect());
+      }
     }
 
     return rows;
@@ -880,34 +930,11 @@ class Query {
    * Connects to the database, via {@link Connection#create}. This method is
    * called by {@link Query#execute}.
    *
-   * ::: tip INFO
-   * When running in a transaction, this method connects to the database via
-   * {@link Transaction#connect}. The first query to be executed in the
-   * transaction runs {@link Transaction#connect} and {@link Transaction#begin},
-   * after which subsequent queries re-use the transaction's connection.
-   * However, once the transaction is {@link Transaction#ended}, connections are
-   * made as usual.
-   * :::
-   *
    * @returns {Promise} The `Promise` from {@link Connection#create}, that is
    * resolved when a connection is established or rejected with a
    * {@link QueryError} on error.
    */
   async connect() {
-    const transaction = this.transaction;
-
-    if (transaction && !transaction.ended) {
-      if (!transaction.connection) {
-        await transaction.connect();
-        await transaction.begin();
-      }
-
-      this.connection = transaction.connection;
-
-      // when running in an active transaction, use the transaction's connection
-      return;
-    }
-
     try {
       this.connection = new this.constructor.Connection();
       return await this.connection.create();
@@ -926,6 +953,10 @@ class Query {
    * when `sql` is passed as an object.
    * @param {array} sql.values The values for the parameterized SQL string, when
    * `sql` is passed as an object.
+   *
+   * ::: tip INFO
+   * This method is called internally by {@link Query#execute}.
+   * :::
    *
    * @returns {object} An object with `text` and `values` properties. Note that
    * when `sql` is passed as a string, the object returned has no `values`
@@ -968,12 +999,6 @@ class Query {
    * Closes the database connection after running the query, via
    * {@link Connection#close}. This method is called by {@link Query#execute}.
    *
-   * ::: tip INFO
-   * When running in a transaction, this method does not close the database
-   * connection.However, if the transaction is {@link Transaction#ended},
-   * connections are closed as usual.
-   * :::
-   *
    * @param {QueryError} [error] A {@link QueryError} from {@link Query#query},
    * if one occurred. This error is then passed to {@link Connection#close}.
    *
@@ -982,15 +1007,10 @@ class Query {
    * {@link QueryError} on error.
    */
   async disconnect(error) {
-    const transaction = this.transaction;
-
-    if (transaction && !transaction.ended) {
-      // do not disconnect when running in an active transaction
-      return;
-    }
-
     try {
-      return await this.connection.close(error);
+      return await (error
+        ? this.connection.close(error)
+        : this.connection.close());
     } catch (e) {
       throw new this.constructor.QueryError(e);
     }

--- a/lib/Transaction.js
+++ b/lib/Transaction.js
@@ -61,13 +61,19 @@ class Transaction {
    * committing (via {@link Transaction#commit}) or rolling back (via
    * {@link Transaction#rollback}) a transaction.
    *
+   * @param {QueryError} [error] The error from {@link Transaction#rollback}, if
+   * it was called with one. This error is then passed to
+   * {@link Connection#close}.
+   *
    * @returns {Promise} The `Promise` from {@link Connection#close}, that is
    * resolved when the connection is closed or rejected with a
    * {@link QueryError} on error.
    */
-  async disconnect() {
+  async disconnect(error) {
     try {
-      return await this.connection.close();
+      return await (error
+        ? this.connection.close(error)
+        : this.connection.close());
     } catch (e) {
       throw new this.constructor.TransactionError(e);
     }
@@ -104,8 +110,9 @@ class Transaction {
        */
       this.started = true;
     } catch (e) {
-      await this.disconnect();
-      throw new this.constructor.TransactionError(e);
+      const beginError = new this.constructor.TransactionError(e);
+      await this.disconnect(beginError);
+      throw beginError;
     }
   }
 
@@ -118,6 +125,7 @@ class Transaction {
    * resolved with the query result.
    */
   async _begin() {
+    // TODO: reject with a QueryError instead
     return this.connection.query('BEGIN');
   }
 
@@ -144,12 +152,14 @@ class Transaction {
        */
       this.ended = true;
     } catch (e) {
-      await this.rollback();
-      throw new this.constructor.TransactionError(e);
+      const commitError = new this.constructor.TransactionError(e);
+      await this.rollback(commitError);
+      throw commitError;
     }
 
-    // do not disconnect within the try..catch so that connection closing errors
-    // don't lead to calling `rollback` after `commit` ran successfully
+    // do not disconnect within the try..catch so that errors closing the
+    // connection don't lead to Transaction#rollback being called (yet `COMMIT`
+    // already ran successfully)
     await this.disconnect();
   }
 
@@ -168,19 +178,38 @@ class Transaction {
    * Rolls back a transaction, via {@link Transaction#_rollback} and afterwards
    * closes the database connection, via {@link Transaction#disconnect}.
    *
+   * @param {QueryError} [error] A {@link QueryError} from {@link Query#query},
+   * or a {@link TransactionError} from {@link Transaction#commit} or
+   * {@link Transaction#rollback}, if one occurs when those methods are run.
+   * This error is then passed to {@link Transaction#disconnect} and finally to
+   * {@link Connection#close}.
+   *
    * @returns {Promise} A `Promise` that is resolved when the transaction is
    * rolled back and the connection closed or rejected with a
    * {@link TransactionError} on error.
    */
-  async rollback() {
+  async rollback(error) {
+    if (this.ended) {
+      // Transaction#rollback is automatically called when a query error occurs.
+      // when a transaction is wrapped in a try..catch block (e.g. in
+      // transactions with a callback) and Transaction#rollback is called in the
+      // catch block, then Transaction#rollback would end up being called twice.
+      return;
+    }
+
     try {
       await this._rollback();
+    } catch (e) {
+      const rollbackError = new this.constructor.TransactionError(e);
+      if (!error) {
+        error = rollbackError;
+      }
+      throw rollbackError;
+    } finally {
+      // update state and disconnect whether or not the ROLLBACK call fails
       this.active = false;
       this.ended = true;
-    } catch (e) {
-      throw new this.constructor.TransactionError(e);
-    } finally {
-      await this.disconnect();
+      await (error ? this.disconnect(error) : this.disconnect());
     }
   }
 
@@ -219,12 +248,16 @@ class Transaction {
     try {
       result = await this.callback(this);
     } catch (e) {
+      // NOTE: this error should not be passed to Transaction#rollback. query
+      // errors will have already been passed by Query#execute. so any error
+      // happening here is not a query error and should not end up being passed
+      // to Transaction#disconnect.
       await this.rollback();
       throw e;
     }
 
-    // do not commit within the try..catch, commit does it's own rollback on
-    // failure
+    // do not commit within the try..catch, since Transaction#commit itself
+    // calls Transaction#rollback on failure
     await this.commit();
 
     return result;

--- a/test/Query.spec.js
+++ b/test/Query.spec.js
@@ -227,114 +227,6 @@ describe('Query', () => {
         new QueryError(new Error('connection error'))
       );
     });
-
-    describe('within a transaction', () => {
-      let transactionBegin;
-      let transactionConnect;
-      let queryCreateConnection;
-      let transaction;
-
-      beforeEach(() => {
-        transactionBegin = sinon.stub(Transaction.prototype, 'begin');
-        transactionConnect = sinon.stub(Transaction.prototype, 'connect');
-        queryCreateConnection = sinon.stub(
-          Query.Connection.prototype,
-          'create'
-        );
-        transaction = new Transaction();
-        transactionConnect
-          .onFirstCall()
-          .callsFake(() => {
-            transaction.connection = 'connection 1';
-          })
-          .onSecondCall()
-          .callsFake(() => {
-            transaction.connection = 'connection 2';
-          });
-      });
-
-      afterEach(() => {
-        transactionConnect.restore();
-        transactionBegin.restore();
-        queryCreateConnection.restore();
-      });
-
-      it('does not create a connection via Connection.prototype.create', async () => {
-        await transaction.models.User.query.connect();
-        await expect(queryCreateConnection, 'was not called');
-      });
-
-      it('connects via Transaction.prototype.connect', async () => {
-        await transaction.models.User.query.connect();
-        await expect(transactionConnect, 'to have calls satisfying', () =>
-          transactionConnect()
-        );
-      });
-
-      it('runs Transaction.protype.begin', async () => {
-        await transaction.models.User.query.connect();
-        await expect(transactionBegin, 'to have calls satisfying', () =>
-          transactionBegin()
-        );
-      });
-
-      describe('for multiple Query instances', () => {
-        it('connects once', async () => {
-          await transaction.models.User.query.connect();
-          await transaction.models.User.query.connect();
-          await expect(transactionConnect, 'to have calls satisfying', () =>
-            transactionConnect()
-          );
-        });
-
-        it('begins the transaction once', async () => {
-          await transaction.models.User.query.connect();
-          await transaction.models.User.query.connect();
-          await expect(transactionBegin, 'to have calls satisfying', () =>
-            transactionBegin()
-          );
-        });
-
-        it('re-uses the same transaction connection', async () => {
-          const query1 = transaction.models.User.query;
-          const query2 = transaction.models.User.query;
-          await query1.connect();
-          await query2.connect();
-          await expect(query1.connection, 'to be', 'connection 1');
-          await expect(query2.connection, 'to be', 'connection 1');
-        });
-      });
-
-      describe('when a transaction has ended', () => {
-        beforeEach(() => {
-          transaction.ended = true;
-        });
-
-        it('connects as usual via Connection.prototype.create', async () => {
-          await transaction.models.User.query.connect();
-          await expect(queryCreateConnection, 'to have calls satisfying', () =>
-            queryCreateConnection()
-          );
-        });
-
-        it('does not call Transaction.prototype.connect', async () => {
-          await transaction.models.User.query.connect();
-          await expect(transactionConnect, 'was not called');
-        });
-
-        it('does not call Transaction.prototype.begin', async () => {
-          await transaction.models.User.query.connect();
-          await expect(transactionBegin, 'was not called');
-        });
-
-        it('does not use a transaction connection', async () => {
-          transaction.connection = 'connection 1';
-          const query = transaction.models.User.query;
-          await query.connect();
-          await expect(query.connection, 'not to be', 'connection 1');
-        });
-      });
-    });
   });
 
   describe('Query.prototype.query', () => {
@@ -397,10 +289,8 @@ describe('Query', () => {
       const query = new DummyQuery(User);
       await query.connect();
       await query.disconnect();
-      await expect(
-        close,
-        'to have calls exhaustively satisfying',
-        () => close(undefined) // no error
+      await expect(close, 'to have calls exhaustively satisfying', () =>
+        close()
       );
     });
 
@@ -434,51 +324,6 @@ describe('Query', () => {
         'to be rejected with error exhaustively satisfying',
         new QueryError(new Error('connection close error'))
       );
-    });
-
-    describe('within a transaction', () => {
-      let transactionBegin;
-      let transactionConnect;
-      let queryCloseConnection;
-      let transaction;
-
-      beforeEach(() => {
-        transactionBegin = sinon.stub(Transaction.prototype, 'begin');
-        transactionConnect = sinon.stub(Transaction.prototype, 'connect');
-        queryCloseConnection = sinon.stub(Query.Connection.prototype, 'close');
-        transaction = new Transaction();
-      });
-
-      afterEach(() => {
-        transactionConnect.restore();
-        transactionBegin.restore();
-        queryCloseConnection.restore();
-      });
-
-      it('does not close connections via Connection.prototype.close', async () => {
-        const query = transaction.models.User.query;
-        await query.connect();
-        await query.disconnect();
-        await expect(queryCloseConnection, 'was not called');
-      });
-
-      describe('when a transaction has ended', () => {
-        beforeEach(() => {
-          transaction.ended = true;
-        });
-
-        it('closes connections as usual via Connection.prototype.close', async () => {
-          const query = transaction.models.User.query;
-          query.connection = { close() {} };
-          await query.connect();
-          await query.disconnect();
-          await expect(
-            queryCloseConnection,
-            'to have calls satisfying',
-            () => queryCloseConnection(undefined) // no query error
-          );
-        });
-      });
     });
   });
 
@@ -602,10 +447,8 @@ describe('Query', () => {
         await expect(formatSql, 'to have calls satisfying', () =>
           formatSql('select now() as "now"')
         );
-        await expect(
-          disconnect,
-          'to have calls satisfying',
-          () => disconnect(undefined) // no query error
+        await expect(disconnect, 'to have calls satisfying', () =>
+          disconnect()
         );
       });
 
@@ -649,10 +492,8 @@ describe('Query', () => {
             formatSql('select now() as "now"');
             formatSql('select now() as "now"');
           });
-          await expect(
-            disconnect,
-            'to have calls satisfying',
-            () => disconnect(undefined) // no query error
+          await expect(disconnect, 'to have calls satisfying', () =>
+            disconnect()
           );
         });
 
@@ -786,6 +627,166 @@ describe('Query', () => {
               sql: { text: 'select now()', values: [] }
             }
           );
+        });
+      });
+    });
+
+    describe('within a transaction', () => {
+      let transaction;
+      let User;
+      let Query;
+
+      beforeEach(() => {
+        transaction = new Transaction();
+        User = transaction.models.User;
+        Query = User.Query;
+      });
+
+      afterEach(async () => {
+        await transaction.rollback();
+      });
+
+      it('does not create a connection via Query.prototype.connect', async () => {
+        const connect = sinon.spy(Query.prototype, 'connect');
+        await new Query(User).execute('select now()');
+        await expect(connect, 'was not called');
+        connect.restore();
+      });
+
+      it('does not close connections via Query.prototype.disconnect', async () => {
+        const disconnect = sinon.spy(Query.prototype, 'disconnect');
+        await new Query(User).execute('select now()');
+        await expect(disconnect, 'was not called');
+        disconnect.restore();
+      });
+
+      it('connects via Transaction.prototype.connect', async () => {
+        const connect = sinon.spy(transaction, 'connect');
+        await new Query(User).execute('select now()');
+        await expect(connect, 'to have calls satisfying', () => connect());
+      });
+
+      it('runs Transaction.protype.begin', async () => {
+        const begin = sinon.spy(transaction, 'begin');
+        await new Query(User).execute('select now()');
+        await expect(begin, 'to have calls satisfying', () => begin());
+      });
+
+      describe('for multiple invocations', () => {
+        let connect;
+        let begin;
+
+        beforeEach(() => {
+          connect = sinon.spy(transaction, 'connect');
+          begin = sinon.spy(transaction, 'begin');
+        });
+
+        it('connects once', async () => {
+          await new Query(User).execute('select now()');
+          await new Query(User).execute('select now()');
+          await expect(connect, 'to have calls satisfying', () => connect());
+        });
+
+        it('begins the transaction once', async () => {
+          await new Query(User).execute('select now()');
+          await new Query(User).execute('select now()');
+          await expect(begin, 'to have calls satisfying', () => begin());
+        });
+
+        it('re-uses the same transaction connection', async () => {
+          const query1 = new Query(User);
+          const query2 = new Query(User);
+          await query1.execute('select now()');
+          await query2.execute('select now()');
+          await expect(query1.connection, 'to be', query2.connection);
+        });
+      });
+
+      describe('when a transaction has ended', () => {
+        beforeEach(() => {
+          transaction.ended = true;
+        });
+
+        it('connects as usual via Query.prototype.connect', async () => {
+          const connect = sinon.spy(Query.prototype, 'connect');
+          await User.query.execute('select now()');
+          await expect(connect, 'to have calls satisfying', () => connect());
+          connect.restore();
+        });
+
+        it('closes connections as usual via Query.prototype.disconnect', async () => {
+          const disconnect = sinon.spy(Query.prototype, 'disconnect');
+          await User.query.execute('select now()');
+          await expect(disconnect, 'to have calls satisfying', () =>
+            disconnect()
+          );
+          disconnect.restore();
+        });
+
+        it('does not call Transaction.prototype.connect', async () => {
+          const connect = sinon.spy(transaction, 'connect');
+          await User.query.execute('select now()');
+          await expect(connect, 'was not called');
+        });
+
+        it('does not call Transaction.prototype.begin', async () => {
+          const begin = sinon.spy(transaction, 'begin');
+          await User.query.execute('select now()');
+          await expect(begin, 'was not called');
+        });
+
+        it('does not use a transaction connection', async () => {
+          transaction.connection = 'transaction connection';
+          const query = User.query;
+          await query.execute('select now()');
+          await expect(query.connection, 'not to be', 'transaction connection');
+        });
+      });
+
+      describe('when there is a query error', () => {
+        it('calls Transaction.prototype.rollback with the error', async () => {
+          const rollback = sinon.spy(transaction, 'rollback');
+          await expect(
+            User.query.execute('selects now()'),
+            'to be rejected with error satisfying',
+            new QueryError('syntax error at or near "selects"')
+          );
+          await expect(rollback, 'to have calls satisfying', () =>
+            rollback(new QueryError('syntax error at or near "selects"'))
+          );
+          rollback.restore();
+        });
+
+        it('does not call Query.prototype.disconnect', async () => {
+          const disconnect = sinon.spy(Query.prototype, 'disconnect');
+          await expect(User.query.execute('selects now()'), 'to be rejected');
+          await expect(disconnect, 'was not called');
+          disconnect.restore();
+        });
+
+        describe('when a transaction has ended', () => {
+          beforeEach(() => {
+            transaction.ended = true;
+          });
+
+          it('disconnects as usual via Query.prototype.disconnect', async () => {
+            const disconnect = sinon.spy(Query.prototype, 'disconnect');
+            await expect(
+              User.query.execute('selects now()'),
+              'to be rejected with error satisfying',
+              new QueryError('syntax error at or near "selects"')
+            );
+            await expect(disconnect, 'to have calls satisfying', () =>
+              disconnect(new QueryError('syntax error at or near "selects"'))
+            );
+            disconnect.restore();
+          });
+
+          it('does not call Transaction.prototype.rollback', async () => {
+            const rollback = sinon.spy(transaction, 'rollback');
+            await expect(User.query.execute('selects now()'), 'to be rejected');
+            await expect(rollback, 'was not called');
+          });
         });
       });
     });
@@ -2066,7 +2067,9 @@ describe('Query', () => {
       it('improves the FetchError stack trace', async () => {
         const stub = sinon
           .stub(Query.prototype, 'query')
-          .returns(Promise.reject(new Error('fetch error')));
+          .callsFake(async () => {
+            throw new Error('fetch error');
+          });
         await expect(
           new Query(User).fetch(),
           'to be rejected with error satisfying',
@@ -2083,7 +2086,9 @@ describe('Query', () => {
       it('improves the InsertError stack trace', async () => {
         const stub = sinon
           .stub(Query.prototype, 'query')
-          .returns(Promise.reject(new Error('insert error')));
+          .callsFake(async () => {
+            throw new Error('insert error');
+          });
         await expect(
           new Query(User).insert({ name: 'foo' }),
           'to be rejected with error satisfying',
@@ -2100,7 +2105,9 @@ describe('Query', () => {
       it('improves the UpdateError stack trace', async () => {
         const stub = sinon
           .stub(Query.prototype, 'query')
-          .returns(Promise.reject(new Error('update error')));
+          .callsFake(async () => {
+            throw new Error('update error');
+          });
         await expect(
           new Query(User).update({ name: 'foo' }),
           'to be rejected with error satisfying',
@@ -2117,7 +2124,9 @@ describe('Query', () => {
       it('improves the DeleteError stack trace', async () => {
         const stub = sinon
           .stub(Query.prototype, 'query')
-          .returns(Promise.reject(new Error('delete error')));
+          .callsFake(async () => {
+            throw new Error('delete error');
+          });
         await expect(
           new Query(User).delete(),
           'to be rejected with error satisfying',

--- a/test/Transaction.spec.js
+++ b/test/Transaction.spec.js
@@ -13,7 +13,6 @@ describe('Transaction', () => {
   let Connection;
   let Transaction;
   let TransactionError;
-  let User;
 
   before(() => {
     const knorm = new Knorm();
@@ -26,12 +25,16 @@ describe('Transaction', () => {
   });
 
   describe('constructor', () => {
-    it('creates scoped models', () => {
+    let User;
+
+    before(() => {
       User = class extends Model {};
       User.table = 'user';
       User.fields = { name: { type: 'string', primary: true } };
       User.Query = class UserQuery extends User.Query {};
+    });
 
+    it('creates scoped models', () => {
       const transaction = new Transaction();
       const TransactionUser = transaction.models.User;
 
@@ -60,6 +63,16 @@ describe('Transaction', () => {
 
       expect(TransactionUser.prototype.transaction, 'to be', transaction);
       expect(TransactionUser.Query.prototype.transaction, 'to be', transaction);
+    });
+
+    it('does not add an accessor to the parent models and queries', () => {
+      new Transaction(); // eslint-disable-line no-new
+
+      expect(User.transaction, 'to be null');
+      expect(User.Query.transaction, 'to be null');
+
+      expect(User.prototype.transaction, 'to be null');
+      expect(User.Query.prototype.transaction, 'to be null');
     });
   });
 

--- a/test/lib/postgresPlugin.js
+++ b/test/lib/postgresPlugin.js
@@ -19,8 +19,8 @@ const postgresPlugin = knorm => {
         return rows;
       }
 
-      async close() {
-        return this.client.release();
+      async close(error) {
+        return this.client.release(error);
       }
     }
   );


### PR DESCRIPTION
Query errors orignating from Query.prototype.query and proxied
through Query.prototype.disconnect.

- [x] auto-rollback on query errors for transactions without a callback (seems to have been forgotten in knorm v2)
- [x] ensure transactions are marked as failed on query errors
- [x] pass errors from Transaction.prototype.disconnect to Connection.prototype.close